### PR TITLE
Fix startup instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,15 @@ Another Hourは、時間の流れ方を個人がデザインできる革新的�
 ## Quick Start
 ```bash
 # Clone the repository
-git clone https://github.com/kanekop/another-hour-scheduler.git
-cd another-hour-scheduler
+git clone https://github.com/kanekop/another-hour.git
+cd another-hour
 
 # Install dependencies and run
 npm install
-npm start
+npm run dev
 
 # Open in browser
-http://localhost:8080
+http://localhost:3000
 ```
 *For detailed setup, see the [Development Setup Guide](docs/DEVELOPMENT.md).*
 


### PR DESCRIPTION
## Summary
- update repo name in quick start section
- clarify dev instructions to use npm run dev and port 3000

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_684ee98634d0832a8342b592111965cc