### PR TITLE
Add documentation overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ http://localhost:3000
 *For detailed setup, see the [Development Setup Guide](docs/DEVELOPMENT.md).*
 
 ## Documentation
+- [Documentation Index](docs/README.md) - overview of all docs
 - [Time Design Modes](docs/time-design-modes/) - 時間設計モードの詳細
 - [API Reference](docs/api/) - 開発者向けドキュメント
 - [Applications](docs/applications/) - 各アプリケーションの詳細

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,21 @@
+# Documentation Overview
+
+This folder contains all guides, specifications, and notes for the **Another Hour** project.
+
+## Key Documents
+
+- **DEVELOPMENT.md** – development setup guide.
+- **MONOREPO_GUIDE.md** – monorepo organization and migration notes.
+- **project-structure.md** – overview of the overall repo layout.
+
+## Subdirectories
+
+- **time-design-modes/** – all materials on Time Design Modes.
+- **applications/** – documentation for each application (clock, scheduler, etc.).
+- **specifications/** – detailed mode specifications and data formats.
+- **platforms/** – implementation guides for different hardware platforms.
+- **ui-specifications/** – UI design and test specifications.
+- **examples/** – usage examples and sample code.
+- **archive/** – historical docs and migration records.
+
+For a structured walk-through of the repository, start with [`project-structure.md`](./project-structure.md).


### PR DESCRIPTION
## Summary
- document the docs folder with a new `docs/README.md`
- link to the docs index from the main README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684eef7c0024832aa1b47006305ebca0